### PR TITLE
don't use the nsync mutex on arm64

### DIFF
--- a/include/onnxruntime/core/platform/ort_mutex.h
+++ b/include/onnxruntime/core/platform/ort_mutex.h
@@ -101,7 +101,7 @@ std::cv_status OrtCondVar::wait_for(std::unique_lock<OrtMutex>& cond_mutex,
   return steady_clock::now() - steady_now < rel_time ? std::cv_status::no_timeout : std::cv_status::timeout;
 }
 }  // namespace onnxruntime
-#else
+#elif !defined(__aarch64__)
 #include "nsync.h"
 #include <mutex>               //for unique_lock
 #include <condition_variable>  //for cv_status
@@ -186,4 +186,11 @@ std::cv_status OrtCondVar::wait_for(std::unique_lock<OrtMutex>& cond_mutex,
   return steady_clock::now() - steady_now < rel_time ? std::cv_status::no_timeout : std::cv_status::timeout;
 }
 };  // namespace onnxruntime
+#else
+#include <mutex>
+#include <condition_variable>
+namespace onnxruntime {
+using OrtMutex = std::mutex;
+using OrtCondVar = std::condition_variable;
+}  // namespace onnxruntime
 #endif

--- a/onnxruntime/core/platform/posix/ort_mutex.cc
+++ b/onnxruntime/core/platform/posix/ort_mutex.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#if !defined(__aarch64__)
 #include "core/common/common.h"
 #include "core/platform/ort_mutex.h"
 #include <assert.h>
@@ -41,3 +42,4 @@ void OrtCondVar::wait(std::unique_lock<OrtMutex>& lk) {
 }
 
 }  // namespace onnxruntime
+#endif


### PR DESCRIPTION
**Description**: Use C++ synchronization instead of google nsync

**Motivation and Context**
The google nsync synchronization primitives are unreliable on the techlab Cavium ThunderX CPUs. 
See https://github.com/cms-sw/cmssw/issues/32899

Please revert #6 and apply this.  #6 only addresses the symptoms, fortunately that narrowed the window enough to identify the real problem, which is addressed by this PR.